### PR TITLE
Fix Gemini API key env var

### DIFF
--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { LlmProvider, DocumentType, AllDocumentTypeSettings, DocumentTypeSetting } from '../types';
 import {
   DEFAULT_OPENAI_API_KEY_PLACEHOLDER,
+  DEFAULT_GEMINI_API_KEY_PLACEHOLDER,
   DEFAULT_AZURE_OPENAI_API_KEY_PLACEHOLDER,
   DEFAULT_AZURE_OPENAI_ENDPOINT_PLACEHOLDER,
   DEFAULT_AZURE_OPENAI_DEPLOYMENT_NAME_PLACEHOLDER,
@@ -108,8 +109,8 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 
   if (selectedLlmProvider === LlmProvider.GEMINI) {
     apiKeyLabel = "Google Gemini API key (optional)";
-    apiKeyPlaceholder = "Uses process.env.API_KEY if empty";
-    apiKeyHelpText = "If provided, this key is used. Otherwise, relies on a system-level API_KEY environment variable.";
+    apiKeyPlaceholder = DEFAULT_GEMINI_API_KEY_PLACEHOLDER;
+    apiKeyHelpText = "If provided, this key is used. Otherwise, relies on a system-level GEMINI_API_KEY environment variable.";
   } else if (selectedLlmProvider === LlmProvider.AZURE_OPENAI) {
     apiKeyLabel = "Azure OpenAI API key";
     apiKeyPlaceholder = DEFAULT_AZURE_OPENAI_API_KEY_PLACEHOLDER;

--- a/constants.ts
+++ b/constants.ts
@@ -125,6 +125,9 @@ export const DOCUMENT_DESCRIPTIONS: Record<string, string> = {
   'concept': "An explanation of a key concept, technology, or architecture. Aim for clarity and understanding of its purpose and mechanics.",
 };
 
+export const DEFAULT_GEMINI_API_KEY_PLACEHOLDER =
+  "GEMINI_API_KEY_NOT_CONFIGURED (uses process.env.GEMINI_API_KEY if available)";
+
 export const DEFAULT_OPENAI_API_KEY_PLACEHOLDER = "OPENAI_API_KEY_NOT_CONFIGURED (uses process.env.OPENAI_API_KEY if available)";
 export const DEFAULT_AZURE_OPENAI_API_KEY_PLACEHOLDER = "AZURE_OPENAI_API_KEY_NOT_CONFIGURED (uses process.env.AZURE_OPENAI_API_KEY if available)";
 export const DEFAULT_AZURE_OPENAI_ENDPOINT_PLACEHOLDER = "AZURE_OPENAI_ENDPOINT_NOT_CONFIGURED (uses process.env.AZURE_OPENAI_ENDPOINT if available)";

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -30,7 +30,7 @@ const geminiService: LlmService & {
     prompt: string,
     useGrounding: boolean = false
   ): Promise<LlmServiceResponse> => {
-    const effectiveApiKey = apiKey || process.env.API_KEY;
+    const effectiveApiKey = apiKey || process.env.GEMINI_API_KEY;
     if (!effectiveApiKey) {
       throw new Error("API key for Google Gemini is not provided and not found in environment variables.");
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
       },
       resolve: {


### PR DESCRIPTION
## Summary
- use GEMINI_API_KEY environment variable in gemini service
- add placeholder for Gemini API key
- update SettingsModal to show the new placeholder
- simplify vite config to only expose GEMINI_API_KEY

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842578b72f88329a7387f7ddbd40803